### PR TITLE
on session start set frameNumber to 0 to prevent append black screen …

### DIFF
--- a/src/ios/CameraRenderController.h
+++ b/src/ios/CameraRenderController.h
@@ -33,5 +33,6 @@
 @property BOOL tapToTakePicture;
 @property BOOL tapToFocus;
 @property (nonatomic, assign) id delegate;
+@property int64_t frameNumber;
 
 @end

--- a/src/ios/CameraRenderController.m
+++ b/src/ios/CameraRenderController.m
@@ -87,6 +87,7 @@
 
   dispatch_async(self.sessionManager.sessionQueue, ^{
       NSLog(@"Starting session");
+      self.frameNumber = 0;
       [self.sessionManager.session startRunning];
       });
 }
@@ -234,11 +235,10 @@
       
 
     if(self.sessionManager.assetWriterInput.readyForMoreMediaData && self.sessionManager.isRecording) {
-      static int64_t frameNumber = 0;
       NSLog (@"readyForMoreMediaData");
       CVImageBufferRef imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
-      [self.sessionManager.pixelBufferAdaptor appendPixelBuffer:imageBuffer withPresentationTime:CMTimeMake(frameNumber, 25)];
-      frameNumber++;
+      [self.sessionManager.pixelBufferAdaptor appendPixelBuffer:imageBuffer withPresentationTime:CMTimeMake(self.frameNumber, 25)];
+      self.frameNumber++;
     }
     [self.renderLock unlock];
   }


### PR DESCRIPTION
fix bug on re-recording video, black screen is seen because frameNumber isn´t restart.